### PR TITLE
Feat/profiles

### DIFF
--- a/python/letsql/__init__.py
+++ b/python/letsql/__init__.py
@@ -10,6 +10,9 @@ from letsql.expr import api
 from letsql.expr.api import *  # noqa: F403
 from letsql.backends.let import Backend
 from letsql.internal import SessionConfig
+import os 
+from pathlib import Path
+import yaml # noqa: F401
 
 try:
     import importlib.metadata as importlib_metadata
@@ -71,6 +74,79 @@ def connect(session_config: SessionConfig | None = None) -> Backend:
     instance = Backend()
     instance.do_connect(session_config)
     return instance
+def resolve_env_vars(profile):
+    """Resolve environment variables in the profile."""
+    for key, value in profile.items():
+        if isinstance(value, str) and value.startswith("${") and value.endswith("}"):
+            env_var = value[2:-1]
+            resolved_value = os.getenv(env_var)
+            if resolved_value is None:
+                raise ValueError(f"Environment variable '{env_var}' not set")
+            profile[key] = resolved_value
+    return profile
+
+
+def profiles_init(config_path: str = ".xorq/profiles.yaml"):
+    """Initialize the profiles.yaml file with default profiles."""
+    config_path = Path(config_path)
+    if config_path.exists():
+        raise FileExistsError(f"The file '{config_path}' already exists.")
+    print(f"creating profile @ {config_path}")
+    default_profiles = {
+        "profiles": {
+            "postgres": {
+                "backend": "postgres",
+                "host": "examples.letsql.com",
+                "user": "${XORQ_POSTGRES_USER}",
+                "password": "${XORQ_POSTGRES_PASSWORD}", # we could be opinionated about prefix 
+                "database": "letsql"
+            },
+            "my_duckdb": {
+                "backend": "duckdb",
+                "database": ":memory:",
+                "read_only": False,
+                "extensions": None,
+                "allocator_background_threads": False,
+                "http_retry_backoff": 5
+            },
+            "default": {
+                "backend": "letsql",
+            },
+          "snowflake": {
+                "backend": "snowflake",
+                "account": "${XORQ_SNOWFLAKE_ACCOUNT}",
+                "database": "${XORQ_SNOWFLAKE_DATABASE}",
+                "password": "${XORQ_SNOWFLAKE_PASSWORD}",
+                "role": "${XORQ_SNOWFLAKE_ROLE}",
+                "schema": "${XORQ_SNOWFLAKE_SCHEMA}",
+                "user": "${XORQ_SNOWFLAKE_USER}",
+                "warehouse": "${XORQ_SNOWFLAKE_WAREHOUSE}"
+            }
+        }
+    }
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w") as file:
+        yaml.dump(default_profiles, file)
+
+def profiles_connect(profile_name: str, config_path: str = ".xorq/profiles.yaml") -> Backend:
+    """Create a LETSQL backend based on profile configuration."""
+    with open(config_path, "r") as file:
+        profiles = yaml.safe_load(file).get("profiles", {})
+
+    if profile_name not in profiles:
+        raise ValueError(f"Profile '{profile_name}' not found in {config_path}")
+
+    profile = profiles[profile_name]
+    profile = resolve_env_vars(profile)  # Resolve environment variables
+    backend_name= profile.pop("backend")
+    
+
+    if backend_name == "letsql":
+        backend_name ="let"
+
+    backend = load_backend(backend_name)
+    return backend.connect(**profile)
 
 
 def __getattr__(name):

--- a/python/letsql/__init__.py
+++ b/python/letsql/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 
 
-from jinja2 import Template # noqa: F401
+
 from letsql import examples
 from letsql.config import options
 from letsql.expr import api

--- a/python/letsql/__init__.py
+++ b/python/letsql/__init__.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import importlib
 
+
+from jinja2 import Template # noqa: F401
 from letsql import examples
 from letsql.config import options
 from letsql.expr import api
 from letsql.expr.api import *  # noqa: F403
 from letsql.backends.let import Backend
 from letsql.internal import SessionConfig
+from letsql.profiles import ManageProfiles
+
 import os 
 from pathlib import Path
+import warnings
 import yaml # noqa: F401
 
 try:
@@ -23,12 +28,15 @@ __all__ = [  # noqa: PLE0604
     "api",
     "examples",
     "connect",
+    "profiles",
     "options",
     "SessionConfig",
     *api.__all__,
 ]
 
 _CUSTOM_BACKENDS = ["postgres", "snowflake"]
+
+DEFAULT_PROFILE_PATH : str = ".xorq/profiles.yaml"
 
 
 def _load_entry_points():
@@ -71,9 +79,17 @@ def load_backend(name):
 
 def connect(session_config: SessionConfig | None = None) -> Backend:
     """Create a LETSQL backend."""
+    warnings.warn(
+        "Direct connection is discouraged. Use ls.profiles for managing connections. "
+        "Example: ls.profiles.connect('my_profile')",
+        DeprecationWarning,
+        stacklevel=2
+    )
     instance = Backend()
     instance.do_connect(session_config)
+
     return instance
+
 def resolve_env_vars(profile):
     """Resolve environment variables in the profile."""
     for key, value in profile.items():
@@ -85,51 +101,8 @@ def resolve_env_vars(profile):
             profile[key] = resolved_value
     return profile
 
-
-def profiles_init(config_path: str = ".xorq/profiles.yaml"):
-    """Initialize the profiles.yaml file with default profiles."""
-    config_path = Path(config_path)
-    if config_path.exists():
-        raise FileExistsError(f"The file '{config_path}' already exists.")
-    print(f"creating profile @ {config_path}")
-    default_profiles = {
-        "profiles": {
-            "postgres": {
-                "backend": "postgres",
-                "host": "examples.letsql.com",
-                "user": "${XORQ_POSTGRES_USER}",
-                "password": "${XORQ_POSTGRES_PASSWORD}", # we could be opinionated about prefix 
-                "database": "letsql"
-            },
-            "my_duckdb": {
-                "backend": "duckdb",
-                "database": ":memory:",
-                "read_only": False,
-                "extensions": None,
-                "allocator_background_threads": False,
-                "http_retry_backoff": 5
-            },
-            "default": {
-                "backend": "letsql",
-            },
-          "snowflake": {
-                "backend": "snowflake",
-                "account": "${XORQ_SNOWFLAKE_ACCOUNT}",
-                "database": "${XORQ_SNOWFLAKE_DATABASE}",
-                "password": "${XORQ_SNOWFLAKE_PASSWORD}",
-                "role": "${XORQ_SNOWFLAKE_ROLE}",
-                "schema": "${XORQ_SNOWFLAKE_SCHEMA}",
-                "user": "${XORQ_SNOWFLAKE_USER}",
-                "warehouse": "${XORQ_SNOWFLAKE_WAREHOUSE}"
-            }
-        }
-    }
-
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with config_path.open("w") as file:
-        yaml.dump(default_profiles, file)
-
-def profiles_connect(profile_name: str, config_path: str = ".xorq/profiles.yaml") -> Backend:
+#TODO: this can also be part of manage profiles , but manage profiles has all the create update etc
+def profile_connect(profile_name: str, config_path: str = DEFAULT_PROFILE_PATH) -> Backend:
     """Create a LETSQL backend based on profile configuration."""
     with open(config_path, "r") as file:
         profiles = yaml.safe_load(file).get("profiles", {})
@@ -147,6 +120,25 @@ def profiles_connect(profile_name: str, config_path: str = ".xorq/profiles.yaml"
 
     backend = load_backend(backend_name)
     return backend.connect(**profile)
+
+class LetSQL_dummy:
+    def __init__(self):
+        self._profiles = None
+
+    @property
+    def profiles(self):
+        if self._profiles is None:
+            self._profiles = ManageProfiles(
+                DEFAULT_PROFILE_PATH, 
+                connect_method=profile_connect
+            )
+        return self._profiles
+
+#TODO: prolly a better way to do this
+_instance = LetSQL_dummy()
+
+# Export the profiles property
+profiles = _instance.profiles
 
 
 def __getattr__(name):

--- a/python/letsql/profiles.py
+++ b/python/letsql/profiles.py
@@ -108,5 +108,15 @@ class ManageProfiles:
         """Write all changes made to the profiles object to the profiles.yaml file."""
         with open(self.config_path, "w") as file:
             yaml.dump(self.profiles, file)
-   
+
+    def load_profiles(self):
+        """Load profiles from the YAML file.
+        """
+        if not self.config_path.exists():
+            raise FileNotFoundError(f"Profile file not found at {self.config_path}")
+            
+        with open(self.config_path, "r") as file:
+            self.profiles = yaml.safe_load(file)
+        return self.profiles["profiles"]
+    
         

--- a/python/letsql/profiles.py
+++ b/python/letsql/profiles.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+import yaml  # noqa: F401
+from typing import Callable, Optional
+from letsql.backends.let import Backend
+
+from pathlib import Path
+import yaml  # noqa: F401
+from typing import Callable, Optional
+from letsql.backends.let import Backend
+
+class ManageProfiles:
+    def __init__(self, config_path: str, connect_method: Optional[Callable] = None):
+        self.config_path = Path(config_path)
+        if not self.config_path.exists():
+            self.init_profiles()
+        with open(self.config_path, "r") as file:
+            self.profiles = yaml.safe_load(file)
+
+        self._connect_method = connect_method
+    #TODO: still just uses the path to file
+    #so profile object must be saved before it can be used 
+    def connect(self, profile_name: str) -> Backend:
+        """Connect using a profile name.
+        """
+        if self._connect_method is None:
+            raise ValueError("No connect method provided. Initialize with connect_method")
+        return self._connect_method(profile_name, self.config_path)
+
+    def __iter__(self):
+        return iter(self.profiles["profiles"])
+    def __eq__(self, other):
+        return self.profiles == other.profiles
+
+    def __repr__(self):
+        return f"ManageProfiles({self.config_path})"
+
+    def connect(self, profile_name: str) -> Backend:
+        """Connect using a profile name.
+        """
+        if self._connect_method is None:
+            raise ValueError("No connect method provided. Initialize with connect_method")
+        return self._connect_method(profile_name, self.config_path)
+
+    def init_profiles(self):
+        """Initialize the profiles.yaml file with default profiles."""
+        if self.config_path.exists():
+            raise FileExistsError(f"The file '{self.config_path}' already exists.")
+        print(f"creating profile @ {self.config_path}")
+        default_profiles = {
+            "profiles": {
+                "default":{
+                    "backend": "letsql"
+                }
+ 
+            }
+        }
+        
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.config_path.open("w") as file:
+            yaml.dump(default_profiles, file)
+        self.profiles = default_profiles
+        return default_profiles
+    # Just returning what it did but we can also return the profiles object or nothing 
+    def add_profile(self, profile_name: str, profile_kwargs: dict):
+        """Create a new profile in the profiles.yaml file using Jinja2."""
+        if profile_name in self.profiles["profiles"]:
+            raise ValueError(f"Profile '{profile_name}' already exists in {self.config_path}")
+
+        # Directly add the profile without using Jinja2 template
+        self.profiles["profiles"][profile_name] = profile_kwargs
+        return self.profiles["profiles"][profile_name]
+
+    def deep_merge(self, base_dict: dict, update_dict: dict) -> dict:
+        #dont know if we need this but we got it 
+        """Deep merge two dictionaries."""
+        merged = base_dict.copy()
+        for key, value in update_dict.items():
+            if (
+                key in merged 
+                and isinstance(merged[key], dict) 
+                and isinstance(value, dict)
+            ):
+                merged[key] = self.deep_merge(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+
+    def update_profile(self, profile_name: str, profile_kwargs: dict):
+        """Update an existing profile in the profiles.yaml file."""
+        if profile_name not in self.profiles["profiles"]:
+            raise ValueError(f"Profile '{profile_name}' does not exist in {self.config_path}")
+
+        current_profile = self.profiles["profiles"][profile_name]
+        merged_profile = self.deep_merge(current_profile, profile_kwargs)
+        self.profiles["profiles"][profile_name] = merged_profile
+        
+        return self.profiles["profiles"][profile_name]
+
+    def delete_profile(self, profile_name: str):
+        """Delete an existing profile from the profiles.yaml file."""
+        if profile_name not in self.profiles["profiles"]:
+            raise ValueError(f"Profile '{profile_name}' does not exist in {self.config_path}")
+
+        deleted_profile = self.profiles["profiles"].pop(profile_name)
+        return deleted_profile
+
+    def save_profiles(self):
+        """Write all changes made to the profiles object to the profiles.yaml file."""
+        with open(self.config_path, "w") as file:
+            yaml.dump(self.profiles, file)
+   
+        


### PR DESCRIPTION
I am just opening a draft PR for feedback on the profiles. 
You can still use `ls.connect` but it throws a warning.

here is some example usage

```python
import letsql as ls
#profiles init makes a default file at .xorq/profiles.yaml
#currently connect still expects the state to be saved before connect is used
#ls.profiles.profiles  you could pass this to ls.connect but prolly needs getters and setters here 
# I assume users can manage thier own .env files

#you can also just use the profiles.yaml file directly
#ls.profiles.load_profiles("profiles.yaml")
# Add a new PostgreSQL profile
postgres_profile = ls.profiles.add_profile(
    "my_postgres",
    {
        "backend": "postgres",
        "host": "examples.letsql.com",
        "port": 5432,
        "database": "letsql",
        "user": "${POSTGRES_USER}",
        "password": "${POSTGRES_PASSWORD}"
    }
)

# Add a new Snowflake profile
snowflake_profile = ls.profiles.add_profile(
    "my_snowflake",
    {
        "backend": "snowflake",
        "account": "${XORQ_SNOWFLAKE_ACCOUNT}",
        "database": "SNOWFLAKE_SAMPLE_DATA",
        "schema": "PUBLIC",
        "warehouse": "COMPUTE_WH",
        "role": "PUBLIC",
        "user": "${XORQ_SNOWFLAKE_USER}",
        "password": "${XORQ_SNOWFLAKE_PASSWORD}"
    }
)

# Save changes to profiles.yaml
ls.profiles.save_profiles()

snow_con = ls.profiles.connect("my_snowflake")

postgres_con = ls.profiles.connect("my_postgres")


# Update existing profile with new settings
ls.profiles.update_profile(
    "my_postgres",
    {

            "application_name": "my_app",
            "connect_timeout": 10
        }

)



#save delete & update  
ls.profiles.delete_profile("my_snowflake")

ls.profiles.save_profiles()

###warning

ls.connect() # will raise an error if no profile is set

# >> ls.connect()
# <stdin>:1: DeprecationWarning: Direct connection is discouraged. Use ls.profiles for managing connections. Example: ls.profiles.connect('my_profile')
# <letsql.backends.let.Backend object at 0x7ffff5b2cf80>

>>> import letsql as ls
>>> ls.profiles.load_profiles()
{'default': {'backend': 'letsql'}, 'letsql2': {'backend': 'letsql'}, 'my_postgres': {'application_name': 'my_app', 'backend': 'postgres', 'connect_timeout': 10, 'database': 'letsql', 'host': 'examples.letsql.com', 'password': '${POSTGRES_PASSWORD}', 'port': 5432, 'user': '${POSTGRES_USER}'}, 'my_snowflake': {'account': '${XORQ_SNOWFLAKE_ACCOUNT}', 'backend': 'snowflake', 'database': 'SNOWFLAKE_SAMPLE_DATA', 'password': '${XORQ_SNOWFLAKE_PASSWORD}', 'role': 'PUBLIC', 'schema': 'PUBLIC', 'user': '${XORQ_SNOWFLAKE_USER}', 'warehouse': 'COMPUTE_WH'}, 'new_profile': {'new': 'val'}}
```
