### PR TITLE
fix: dedupe yaml seralization

### DIFF
--- a/python/xorq/ibis_yaml/compiler.py
+++ b/python/xorq/ibis_yaml/compiler.py
@@ -120,13 +120,17 @@ class YamlExpressionTranslator:
             schema_registry=SchemaRegistry(),
             profiles=freeze(profiles or {}),
         )
+
         schema_ref = context.schema_registry._register_expr_schema(expr)
+
         expr_dict = translate_to_yaml(expr, context)
         expr_dict = freeze({**dict(expr_dict), "schema_ref": schema_ref})
 
+        context = context.finalize_definitions()
+
         return freeze(
             {
-                "definitions": {"schemas": context.schema_registry.schemas},
+                "definitions": context.definitions,
                 "expression": expr_dict,
             }
         )
@@ -140,7 +144,9 @@ class YamlExpressionTranslator:
             schema_registry=SchemaRegistry(),
             profiles=freeze(profiles or {}),
         )
+
         context = context.update_definitions(freeze(yaml_dict.get("definitions", {})))
+
         expr_dict = freeze(yaml_dict["expression"])
         return translate_from_yaml(expr_dict, freeze(context))
 

--- a/python/xorq/ibis_yaml/tests/test_basic.py
+++ b/python/xorq/ibis_yaml/tests/test_basic.py
@@ -19,7 +19,10 @@ def test_unbound_table(t, compiler):
 def test_field(t, compiler):
     expr = t.a
     yaml_dict = compiler.to_yaml(expr)
-    expression = yaml_dict["expression"]
+
+    node_ref = yaml_dict["expression"]["node_ref"]
+
+    expression = yaml_dict["definitions"]["nodes"][node_ref]
     assert expression["op"] == "Field"
     assert expression["name"] == "a"
     assert expression["type"] == {"name": "Int64", "nullable": True}
@@ -47,7 +50,6 @@ def test_binary_op(t, compiler):
     yaml_dict = compiler.to_yaml(expr)
     expression = yaml_dict["expression"]
     assert expression["op"] == "Add"
-    assert expression["args"][0]["op"] == "Field"
     assert expression["args"][1]["op"] == "Literal"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)

--- a/python/xorq/ibis_yaml/tests/test_benchmark.py
+++ b/python/xorq/ibis_yaml/tests/test_benchmark.py
@@ -1,0 +1,52 @@
+import pytest
+
+import xorq as xo
+from xorq import _
+from xorq.ibis_yaml.compiler import BuildManager
+
+
+@pytest.mark.benchmark
+def test_baseball_stats_compilation(build_dir):
+    pg = xo.postgres.connect_examples()
+
+    batting_old = (
+        pg.table("batting")
+        .filter(_.yearID < 2000)
+        .filter(_.yearID >= 1990)
+        .mutate(batting_avg=_.H / _.AB, era=_.yearID.cast("int32"))
+    )
+
+    batting_recent = (
+        pg.table("batting")
+        .filter(_.yearID >= 2000)
+        .mutate(batting_avg=_.H / _.AB, era=_.yearID.cast("int32"))
+    )
+
+    all_batting = batting_old.union(batting_recent)
+
+    league_averages = all_batting.group_by(["yearID", "lgID"]).aggregate(
+        league_avg=_.batting_avg.mean(), league_HR_avg=_.HR.mean()
+    )
+
+    normalized_stats = all_batting.join(league_averages, ["yearID", "lgID"]).mutate(
+        avg_vs_league=_.batting_avg - _.league_avg, HR_vs_league=_.HR - _.league_HR_avg
+    )
+
+    prev_year_stats = (
+        normalized_stats.order_by(["playerID", "yearID"])
+        .group_by("playerID")
+        .mutate(
+            prev_year_avg=_.batting_avg.lag(1).over(order_by=_.yearID),
+            prev_year_HR=_.HR.lag(1).over(order_by=_.yearID),
+            three_year_avg=_.batting_avg.mean().over(
+                order_by=_.yearID, window=xo.window(preceding=2, following=0)
+            ),
+        )
+    )
+
+    build_manager = BuildManager(build_dir)
+
+    expr_hash = build_manager.compile_expr(prev_year_stats)
+
+    assert isinstance(expr_hash, str)
+    assert len(expr_hash) > 0

--- a/python/xorq/ibis_yaml/tests/test_relations.py
+++ b/python/xorq/ibis_yaml/tests/test_relations.py
@@ -4,14 +4,14 @@ import xorq.vendor.ibis as ibis
 def test_filter(compiler, t):
     expr = t.filter(t.a > 0)
     yaml_dict = compiler.to_yaml(expr)
-    expression = yaml_dict["expression"]
+    node_ref = yaml_dict["expression"]["node_ref"]
 
-    # Original assertions
+    expression = yaml_dict["definitions"]["nodes"][node_ref]
+
     assert expression["op"] == "Filter"
     assert expression["predicates"][0]["op"] == "Greater"
     assert expression["parent"]["op"] == "UnboundTable"
 
-    # Roundtrip test: compile from YAML and verify equality
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
 
@@ -19,14 +19,14 @@ def test_filter(compiler, t):
 def test_projection(compiler, t):
     expr = t.select(["a", "b"])
     yaml_dict = compiler.to_yaml(expr)
-    expression = yaml_dict["expression"]
+    node_ref = yaml_dict["expression"]["node_ref"]
 
-    # Original assertions
+    expression = yaml_dict["definitions"]["nodes"][node_ref]
+
     assert expression["op"] == "Project"
     assert expression["parent"]["op"] == "UnboundTable"
     assert set(expression["values"]) == {"a", "b"}
 
-    # Roundtrip test
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)
 
@@ -37,7 +37,8 @@ def test_aggregation(compiler, t):
     expression = yaml_dict["expression"]
 
     assert expression["op"] == "Aggregate"
-    assert expression["by"][0]["name"] == "a"
+    node_ref = expression["by"][0]["node_ref"]
+    assert yaml_dict["definitions"]["nodes"][node_ref]["name"] == "a"
     assert expression["metrics"]["avg_c"]["op"] == "Mean"
 
     # Roundtrip test

--- a/python/xorq/ibis_yaml/tests/test_subquery.py
+++ b/python/xorq/ibis_yaml/tests/test_subquery.py
@@ -21,10 +21,12 @@ def test_exists_subquery(compiler):
     filtered = t2.filter(t2.a == t1.a)
     expr = ops.ExistsSubquery(filtered).to_expr()
     yaml_dict = compiler.to_yaml(expr)
+
     expression = yaml_dict["expression"]
 
     assert expression["op"] == "ExistsSubquery"
-    assert expression["rel"]["op"] == "Filter"
+    node_ref = expression["rel"]["node_ref"]
+    assert yaml_dict["definitions"]["nodes"][node_ref]["op"] == "Filter"
 
     roundtrip_expr = compiler.from_yaml(yaml_dict)
     assert roundtrip_expr.equals(expr)

--- a/python/xorq/ibis_yaml/tests/test_window_functions.py
+++ b/python/xorq/ibis_yaml/tests/test_window_functions.py
@@ -37,7 +37,9 @@ def test_aggregation_window(compiler, t):
         )
 
         yaml_dict = compiler.to_yaml(expr)
-        expression = yaml_dict["expression"]
+        node_ref = yaml_dict["expression"]["node_ref"]
+
+        expression = yaml_dict["definitions"]["nodes"][node_ref]
         assert expression["op"] == "Project"
         window_func = expression["values"]["mean_c"]
         assert window_func["op"] == "WindowFunction"
@@ -52,8 +54,6 @@ def test_aggregation_window(compiler, t):
             assert "end" not in window_func
         else:
             assert window_func["end"] == following
-
-        assert window_func["group_by"][0]["name"] == "a"
 
 
 def test_row_number_simple_roundtrip(compiler, t):


### PR DESCRIPTION
example expr.yaml file with nodes:
```python
from xorq.ibis_yaml.compiler import BuildManager
from xorq.common.utils.defer_utils import deferred_read_parquet

parquet_path = ls.config.options.pins.get_path("awards_players")

backend = ls.duckdb.connect()

awards_players = deferred_read_parquet(backend, parquet_path, table_name="awards_players")

expr = awards_players.playerID.count()

```

```yaml
definitions:
  schemas:
    schema_0:
      playerID:
        name: String
        nullable: true
      awardID:
        name: String
        nullable: true
      yearID:
        name: Int64
        nullable: true
      lgID:
        name: String
        nullable: true
      tie:
        name: String
        nullable: true
      notes:
        name: String
        nullable: true
  nodes:
    20b6b103e6b3f2b3f511fba4ca3a854a:
      op: Field
      name: playerID
      relation:
        op: Read
        method_name: read_parquet
        name: awards_players
        schema_ref: schema_0
        profile: 4e998255e4b86d1a4608f5758a3a33be
        read_kwargs:
        - - source_list
          - /home/hussainsultan/.cache/pins-py/gs_d3037fb8920d01eb3b262ab08d52335c89ba62aa41299e5236f01807aa8b726d/awards_players/20240711T171119Z-886c4/awards_players.parquet
        - - table_name
          - awards_players
      type:
        name: String
        nullable: true
expression:
  op: Count
  type:
    name: Int64
    nullable: true
  args:
  - node_ref: 20b6b103e6b3f2b3f511fba4ca3a854a
  schema_ref: null
```
